### PR TITLE
Semaphore cancellation should increment semaphore value

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Semaphore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Semaphore.xcscheme
@@ -40,8 +40,15 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "LIBDISPATCH_COOPERATIVE_POOL_STRICT"
+            value = "1"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/Sources/Semaphore/AsyncSemaphore.swift
+++ b/Sources/Semaphore/AsyncSemaphore.swift
@@ -161,9 +161,12 @@ public final class AsyncSemaphore: @unchecked Sendable {
         
         value -= 1
         if value >= 0 {
-            unlock()
+            defer { unlock() }
             // All code paths check for cancellation
-            try Task.checkCancellation()
+            if Task.isCancelled {
+                value += 1
+                throw CancellationError()
+            }
             return
         }
         

--- a/Tests/SemaphoreTests/AsyncSemaphoreTests.swift
+++ b/Tests/SemaphoreTests/AsyncSemaphoreTests.swift
@@ -110,7 +110,7 @@ final class AsyncSemaphoreTests: XCTestCase {
             let ex1 = expectation(description: "wait")
             ex1.isInverted = true
             let ex2 = expectation(description: "woken")
-            Task {
+            let task = Task {
                 await sem.wait()
                 ex1.fulfill()
                 ex2.fulfill()
@@ -121,6 +121,7 @@ final class AsyncSemaphoreTests: XCTestCase {
             
             // When a signal occurs, then the suspended task is resumed.
             sem.signal()
+            await task.value
             wait(for: [ex2], timeout: 0.5)
         }
     }
@@ -140,6 +141,7 @@ final class AsyncSemaphoreTests: XCTestCase {
         }
         try await Task.sleep(nanoseconds: 100_000_000)
         task.cancel()
+        await task.value
         wait(for: [ex], timeout: 1)
     }
     
@@ -163,6 +165,7 @@ final class AsyncSemaphoreTests: XCTestCase {
             ex.fulfill()
         }
         task.cancel()
+        await task.value
         wait(for: [ex], timeout: 5)
     }
     
@@ -179,7 +182,7 @@ final class AsyncSemaphoreTests: XCTestCase {
         let ex1 = expectation(description: "wait")
         ex1.isInverted = true
         let ex2 = expectation(description: "woken")
-        Task {
+        let taskTwo = Task {
             await sem.wait()
             ex1.fulfill()
             ex2.fulfill()
@@ -190,6 +193,7 @@ final class AsyncSemaphoreTests: XCTestCase {
         
         // When a signal occurs, then the suspended task is resumed.
         sem.signal()
+        await taskTwo.value
         wait(for: [ex2], timeout: 0.5)
     }
     
@@ -211,7 +215,7 @@ final class AsyncSemaphoreTests: XCTestCase {
         let ex1 = expectation(description: "wait")
         ex1.isInverted = true
         let ex2 = expectation(description: "woken")
-        Task {
+        let taskTwo = Task {
             await sem.wait()
             ex1.fulfill()
             ex2.fulfill()
@@ -222,6 +226,7 @@ final class AsyncSemaphoreTests: XCTestCase {
         
         // When a signal occurs, then the suspended task is resumed.
         sem.signal()
+        await taskTwo.value
         wait(for: [ex2], timeout: 0.5)
     }
 


### PR DESCRIPTION
I found a few things:

1. I think the semaphore should be incremented before throwing in the case of an early cancellation.
2. The current tests don't cover incrementing the semaphore, when cancelling. When commenting out the `value += 1` line in main or lines with the changes from this PR for incrementing the value the tests still pass.
3. Many tests fail when running on an iOS simulator or with LIBDISPATCH_COOPERATIVE_POOL_STRICT=1 enabled. This is because of wait(for:timeout:) blocking the cooperative thread pool.

---

1. The fix is simple:

```swift
if value >= 0 {
    defer { unlock() }
    // All code paths check for cancellation
    if Task.isCancelled {
        value += 1
        throw CancellationError()
    }
    return
}
```

---

2. For this I added tests. I also added some helper code to avoid the problem of 3.

---

3. I added an async helper here for timeouts in my test. It's also possible to fix tests by awaiting tasks before waiting for certain expectations.

```swift
func test_wait_suspends_on_zero_semaphore_until_signal() async {
  // ...
  let task = Task {
      await sem.wait()
      ex1.fulfill()
      ex2.fulfill()
  }
  
  // Then the task is initially suspended.
  wait(for: [ex1], timeout: 0.5)
  
  // When a signal occurs, then the suspended task is resumed.
  sem.signal()
  await task.value
  wait(for: [ex2], timeout: 0.5)
}

```

But after experimenting with this I think it's not nice to use wait in async test functions, if test destinations with a cooperative thread pool size of 1 should be supported. Ideally there would be some async version of wait from XCTest that doesn't block. But as far as I know this doesn't exist.