### PR TITLE
Use AsyncStream<Never> for waitUnlessCancelled

### DIFF
--- a/Sources/Semaphore/AsyncSemaphore.swift
+++ b/Sources/Semaphore/AsyncSemaphore.swift
@@ -81,10 +81,7 @@ public final class AsyncSemaphore: @unchecked Sendable {
     private var suspensions: [Suspension] = []
     
     /// The lock that protects `value` and `suspensions`.
-    ///
-    /// It is recursive in order to handle cancellation (see the implementation
-    /// of ``waitUnlessCancelled()``).
-    private let _lock = NSRecursiveLock()
+    private let _lock = NSLock()
     
     // MARK: - Creating a Semaphore
     

--- a/Tests/SemaphoreTests/AsyncSemaphoreTests.swift
+++ b/Tests/SemaphoreTests/AsyncSemaphoreTests.swift
@@ -394,4 +394,13 @@ final class AsyncSemaphoreTests: XCTestCase {
             XCTAssertEqual(effectiveMaxConcurrentRuns, maxConcurrentRuns)
         }
     }
+
+    func test_async_throwing_stream_closure_runs_synchronously() {
+        var continuation: AsyncThrowingStream<Never, Error>.Continuation!
+        let stream: AsyncThrowingStream<Never, Error> = AsyncThrowingStream<Never, Error> {
+            continuation = $0
+        }
+        XCTAssertNotNil(continuation)
+        _ = stream
+    }
 }


### PR DESCRIPTION
withUnsafeContinuation needs a withTaskCancellationHandler to support cooperative cancellation. One can use the continuation of an AsyncStream instead. AsyncStream supports cancellation. An element type of Never guarantees that there will be no emits. So the stream can only be cancelled or finished.

Credit for this goes to the @pointfreeco episode https://www.pointfree.co/episodes/ep210-clocks-controlling-time where this is approach is explained for the TestClock implementation.

See: https://github.com/pointfreeco/swift-clocks/blob/d8ff0c92e8c9d139356adae1c3c079b12e81d4df/Sources/Clocks/TestClock.swift#L117