### PR TITLE
add missing trailing parentheses in code snippet

### DIFF
--- a/Sources/Semaphore/Documentation.docc/Documentation.md
+++ b/Sources/Semaphore/Documentation.docc/Documentation.md
@@ -57,7 +57,7 @@ class Downloader {
 
   func download(...) async throws -> Data {
     try await semaphore.waitUnlessCancelled()
-    defer { semaphore.signal }
+    defer { semaphore.signal() }
     return try await ...
   }
 }


### PR DESCRIPTION
`semaphore.signal` → `semaphore.signal()`